### PR TITLE
filter with single quotes returns `400 Bad request`

### DIFF
--- a/src/ODataClient.php
+++ b/src/ODataClient.php
@@ -263,8 +263,13 @@ class ODataClient implements IODataClient
      */
     public function request($method, $requestUri, $body = null)
     {
-        $request = new ODataRequest($method, $this->baseUrl.$requestUri, $this, $this->entityReturnType);
+        $remove[] = "'";
+        $remove[] = '"';
 
+        $requestUri = str_replace($remove, "", $this->baseUrl . $requestUri);
+
+        $request = new ODataRequest($method, $requestUri, $this, $this->entityReturnType);
+        
         if ($body) {
             $request->attachBody($body);
         }


### PR DESCRIPTION
Version 9.0 OData does not support single quotes on query url. So it returns:
`A binary operator with incompatible types was detected. Found operand types 'Edm.Guid' and 'Edm.String' for operator kind 'Equal'.`
Fixed the issue.